### PR TITLE
Replace StInspector with StInspectorPresenter

### DIFF
--- a/Seeker/Object.extension.st
+++ b/Seeker/Object.extension.st
@@ -283,7 +283,7 @@ Object >> seekMe [
 { #category : #'*Seeker' }
 Object >> seekMyInspectors [
 
-	^ StInspector allInstances select: [ :insp | 
+	^ StInspectorPresenter allInstances select: [ :insp | 
 		  insp model inspectedObject == self ]
 ]
 

--- a/Seeker/SeekerInspector.class.st
+++ b/Seeker/SeekerInspector.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #SeekerInspector,
-	#superclass : #StInspector,
+	#superclass : #StInspectorPresenter,
 	#instVars : [
 		'objectTid'
 	],

--- a/Seeker/SeekerInspectorSynchronizer.class.st
+++ b/Seeker/SeekerInspectorSynchronizer.class.st
@@ -76,7 +76,7 @@ SeekerInspectorSynchronizer >> searchNewInspectorsFor: tracer [
 	"Add entries to the inspectors dictionary if a new one is detected"
 
 	tracer isSessionActive ifFalse: [ ^ self ].
-	StInspector allInstances do: [ :each |
+	StInspectorPresenter allInstances do: [ :each |
 		(inspectorAndSeekerNOidsDictionary includesKey: each) ifFalse: [
 			| obj |
 			obj := each model inspectedObject.

--- a/Seeker/StInspector.extension.st
+++ b/Seeker/StInspector.extension.st
@@ -1,4 +1,4 @@
-Extension { #name : #StInspector }
+Extension { #name : #StInspectorPresenter }
 
 { #category : #'*Seeker' }
 StInspector class >> on: aDomainObject [


### PR DESCRIPTION
This PR updates all references to StInspector to use StInspectorPresenter instead, ensuring compatibility with the updated Inspector API.

### Changes
- Updated SeekerInspector superclass from StInspector to StInspectorPresenter  
- Updated StInspector.extension to extend StInspectorPresenter instead
- Updated Object extension method seekMyInspectors to use StInspectorPresenter allInstances
- Updated SeekerInspectorSynchronizer searchNewInspectorsFor: to use StInspectorPresenter allInstances

### Files Modified
- Seeker/SeekerInspector.class.st
- Seeker/StInspector.extension.st
- Seeker/Object.extension.st
- Seeker/SeekerInspectorSynchronizer.class.st

This ensures that Seeker works correctly with the updated Inspector API in modern Pharo versions.